### PR TITLE
feat(random): Allow --random when no search term is provided.

### DIFF
--- a/bin/emoji-cli.js
+++ b/bin/emoji-cli.js
@@ -17,7 +17,7 @@ program
 
 program.parse(process.argv)
 
-if (program.args.length === 0) {
+if (program.args.length === 0 && !program.random) {
   program.help()
 } else {
   emojiCli.search(program.args, {

--- a/lib/search.js
+++ b/lib/search.js
@@ -10,13 +10,17 @@ function search (words, options, cb) {
   cb = typeof cb === 'function' ? cb : false
   var emojis = filter(emojilib, function (emoji, name) {
     if (!emoji.char) return false
-    emoji.weight = intersection(emoji.keywords, words).length * -1
-    if (words.length === 1 && words[0] === name) emoji.weight = -9999
-    if (emoji.weight === 0) return false
-    return true
+    if (words && words.length > 0) {
+      emoji.weight = intersection(emoji.keywords, words).length * -1
+      if (words.length === 1 && words[0] === name) emoji.weight = -9999
+      if (emoji.weight === 0) return false
+      return true
+    } else {
+      return true
+    }
   })
 
-  if (emojis.length === 0) {
+  if (emojis.length === 0 && !options.random) {
     if (cb) return cb([])
     console.log('Emoji not found 😿')
     return


### PR DESCRIPTION
This adds the ability to run `emoji --random` to get a random emoji. Previously you could only get a random emoji if you also provided a search term. Now you can omit the search term and still get a random emoji.
