### PR TITLE
:zap: add the choice of quit from cli as ".exit"

### DIFF
--- a/bin/emoji-cli.js
+++ b/bin/emoji-cli.js
@@ -19,6 +19,8 @@ program
 
 program.parse(argv)
 
+console.log('(To exit, press ^C or choose ".exit")')
+
 emojiCli.search(program.args, {
   random: program.random
 })

--- a/lib/search.js
+++ b/lib/search.js
@@ -30,6 +30,15 @@ function search (keywords, options, cb) {
     })
   }
 
+  if (emojis.length > 1) {
+    emojis.push({
+      keywords: ['.exit'],
+      char: '.exit',
+      category: 'flags',
+      weight: -Infinity
+    })
+  }
+
   if (options.random) {
     random = Math.floor(Math.random() * emojis.length)
     if (cb) return cb([emojis[random].char])
@@ -50,6 +59,10 @@ function search (keywords, options, cb) {
     message: 'Emojis:\n',
     choices: emojis
   }], function (o) {
+    if (o.emoji === '.exit') {
+      console.log('Exit')
+      return
+    }
     ncp.copy(o.emoji, function () {
       console.log('Copied ' + o.emoji)
     })


### PR DESCRIPTION
Fix https://github.com/watilde/emoji-cli/issues/8 requested from @shidhincr

Updates:
- Add a helpful message about the ways to exit from the intaractive cli
- Add a choice to exit

```
$ emoji face
(To exit, press ^C or choose ".exit")
? Emojis:
 (Use arrow keys)
❯ .exit
  😀
  😬
  😁
  😂
  😃
  😄
(Move up and down to reveal more choices)
```
